### PR TITLE
fix(server): expose app2app onramp routes as Vercel functions

### DIFF
--- a/server/api/app2app/[...slug].js
+++ b/server/api/app2app/[...slug].js
@@ -1,0 +1,26 @@
+import app from '../../src/app.js';
+
+/**
+ * Catch-all proxy for every `/api/app2app/*` route (Vercel serverless).
+ *
+ * The app2app onramp routes are defined on the shared Express app
+ * (see server/src/app.ts): /app2app/mobile/challenges, /sessions, and the
+ * /app2app/mobile/attestation/{challenges,registrations} device-attestation
+ * endpoints. Vercel's file-based routing only exposes files under api/, so this
+ * single catch-all forwards all of them to the Express app rather than adding a
+ * separate function file per route.
+ *
+ * Vercel populates the dynamic segments in `req.query.slug`
+ * (e.g. ['mobile','attestation','challenges']); we rebuild the Express path and
+ * preserve any query string before delegating.
+ */
+export default function handler(req, res) {
+  const { slug } = req.query ?? {};
+  const segments = Array.isArray(slug) ? slug : slug ? [slug] : [];
+
+  const queryIndex = req.url?.indexOf('?') ?? -1;
+  const search = queryIndex >= 0 ? req.url.slice(queryIndex) : '';
+
+  req.url = '/app2app/' + segments.join('/') + search;
+  return app(req, res);
+}


### PR DESCRIPTION
The /app2app/mobile/{challenges,sessions} and
/app2app/mobile/attestation/{challenges,registrations} routes are defined on the shared Express app but had no corresponding serverless function under server/api/. Vercel uses file-based routing, so production requests to those paths returned a static 404 without ever invoking (or logging) the Express handler.

Add a single catch-all api/app2app/[...slug].js that forwards every /api/app2app/* request to the Express app, unblocking the app-to-app onramp + App Attest flow against the deployed backend.