### PR TITLE
fix(app2app): self-heal stale App Attest key + reset control, and TestFlight build docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,15 +1,24 @@
 # CDP Configuration for the main app
 EXPO_PUBLIC_CDP_PROJECT_ID=YOUR_PROJECT_ID
-# iOS App Attest App ID in teamID.bundleID form (allowlisted in the CDP project)
+# iOS App Attest App ID in teamID.bundleID form (allowlisted in the CDP project).
+# MUST match the build's signing: teamID == Xcode DEVELOPMENT_TEAM and the
+# bundle id == app.config.ts ios.bundleIdentifier. Required for app2app.
 EXPO_PUBLIC_APP_ATTEST_APP_ID=TEAMID.com.your.bundle
 # CDP project that owns the app2app onramp integration (attestation + onramp
 # mobile endpoints). Defaults to EXPO_PUBLIC_CDP_PROJECT_ID when unset.
 EXPO_PUBLIC_ONRAMP_PROJECT_ID=YOUR_ONRAMP_PROJECT_ID
 
+# Backend base URL. For the Vercel deployment this MUST end in /api (Vercel
+# function routing), e.g. https://<project>.vercel.app/api. For a local server
+# use http://BACKEND_SERVER:3000 (no /api suffix).
 EXPO_PUBLIC_BASE_URL=http://BACKEND_SERVER:3000
 
-# Expo Go: true (use expo-crypto)
-# TestFlight: false (use react-native-quick-crypto)
+# Crypto implementation selector. THIS MATTERS FOR APP2APP / APP ATTEST:
+# - true  -> Expo Go (npx expo start): uses expo-crypto. App Attest returns a
+#            MOCK attestation that the server rejects — app2app will NOT work.
+# - false -> Native/dev/TestFlight/App Store builds (npx expo run:ios, archives):
+#            uses react-native-quick-crypto + the real Secure Enclave module.
+# Any distributable (TestFlight/App Store) build MUST set this to false.
 EXPO_PUBLIC_USE_EXPO_CRYPTO=true
 
 # Optional: verbose client-side app2app / App Attest debug logging.

--- a/README.md
+++ b/README.md
@@ -183,6 +183,68 @@ ipconfig getifaddr en0
 
 **Push notifications work automatically** via Expo Push Service - no additional setup needed!
 
+## Building for TestFlight / App Store (App2App + App Attest)
+
+> **Heads up:** both `/ios/` and `.env` are **git-ignored**. A fresh clone has
+> neither, so you must (1) create a real `.env` and (2) regenerate the native
+> project with `expo prebuild`. A teammate building "from the repo" with no `.env`
+> is the most common cause of a build that installs but fails sign-in / app2app.
+
+### 1. Create a real `.env` (not the Expo Go defaults)
+
+For a distributable build the app2app device-attestation flow needs all of these,
+and **`EXPO_PUBLIC_USE_EXPO_CRYPTO` must be `false`** (otherwise App Attest uses a
+mock attestation the server rejects):
+
+```bash
+EXPO_PUBLIC_CDP_PROJECT_ID=<your-cdp-project-id>
+EXPO_PUBLIC_ONRAMP_PROJECT_ID=<cdp-project-that-owns-app2app>   # often the same id
+EXPO_PUBLIC_APP_ATTEST_APP_ID=<TEAMID>.<bundleId>              # e.g. ABCDE12345.com.your.bundle
+EXPO_PUBLIC_BASE_URL=https://<your-project>.vercel.app/api      # NOTE the /api suffix for Vercel
+EXPO_PUBLIC_USE_EXPO_CRYPTO=false                              # REQUIRED for native/TestFlight builds
+IOS_BUILD_NUMBER=<n>                                           # bump for every upload; must be unique & increasing
+```
+
+These `EXPO_PUBLIC_*` values are **inlined into the JS bundle at build time**, so
+edit `.env` *before* archiving — changing it later requires a rebuild.
+
+### 2. Generate the native project + pods
+
+```bash
+npx expo prebuild -p ios     # regenerates /ios from app.config.ts
+cd ios && pod install && cd ..
+```
+
+`expo prebuild` derives all native iOS config from `app.config.ts`, including the
+App Attest entitlement (`com.apple.developer.devicecheck.appattest-environment =
+production`), the `LSApplicationQueriesSchemes` (incl. `com.coinbase.consumer`),
+the bundle id, and the build number (from `IOS_BUILD_NUMBER`). It does **not**
+create `.env` or set your Xcode signing team.
+
+### 3. Archive + upload
+
+```bash
+open ios/OnrampV2Demo.xcworkspace
+```
+
+1. Select the **OnrampV2Demo** target → **Signing & Capabilities** → set your
+   **Team** (must match the team id in `EXPO_PUBLIC_APP_ATTEST_APP_ID`).
+2. Set the run destination to **Any iOS Device (arm64)**.
+3. **Product → Archive**.
+4. In the Organizer, **Distribute App → App Store Connect → Upload** (Xcode
+   creates/uses the distribution cert via your account).
+
+### App Attest notes
+
+- App Attest keys are stored in the iOS **keychain**, which **survives app
+  delete/reinstall** for the same bundle id, and a key is bound to its App Attest
+  **environment** (dev sandbox vs production). A key created by a local/dev build
+  can therefore be reused — and rejected at the signature step — by a later
+  TestFlight build on the same device.
+- The app self-heals (resets the key, re-registers, retries once) on a signature
+  error, and the Home screen has a **"Reset device attestation"** button to force
+  a fresh key manually.
+
 ## Using the App
 
 ### First Time Setup
@@ -372,9 +434,13 @@ Check Expo logs:
 
 | Variable | Description |
 |----------|-------------|
-| `EXPO_PUBLIC_CDP_PROJECT_ID` | Your CDP project ID |
-| `EXPO_PUBLIC_BASE_URL` | Backend server URL (public URL for webhooks, or `http://localhost:3000` for local testing) |
-| `EXPO_PUBLIC_USE_EXPO_CRYPTO` | `true` for Expo Go (`npx expo start`), `false` for dev builds (`npx expo run:ios`) |
+| `EXPO_PUBLIC_CDP_PROJECT_ID` | Your CDP project ID (embedded wallet / sign-in) |
+| `EXPO_PUBLIC_BASE_URL` | Backend server URL. For Vercel it must end in `/api`; for a local server use `http://localhost:3000` |
+| `EXPO_PUBLIC_USE_EXPO_CRYPTO` | `true` for Expo Go (`npx expo start`); **`false`** for dev/native/TestFlight builds (`npx expo run:ios`, archives). Must be `false` for app2app/App Attest to work |
+| `EXPO_PUBLIC_ONRAMP_PROJECT_ID` | CDP project that owns the app2app onramp integration (attestation + onramp-mobile endpoints). Defaults to `EXPO_PUBLIC_CDP_PROJECT_ID` |
+| `EXPO_PUBLIC_APP_ATTEST_APP_ID` | iOS App Attest App ID in `teamID.bundleID` form; must match the build's signing team + bundle id and be allowlisted in the CDP project (required for app2app) |
+| `EXPO_PUBLIC_APP2APP_VERBOSE` | Optional. `1` enables step-by-step app2app / App Attest debug logs on device |
+| `IOS_BUILD_NUMBER` | iOS build number (`CFBundleVersion`); bump for every TestFlight/App Store upload |
 
 ### Required (Server `.env`)
 

--- a/app.config.ts
+++ b/app.config.ts
@@ -42,7 +42,12 @@ const config: ExpoConfig = {
       // App Store / TestFlight builds.
       entitlements: {
         'com.apple.developer.devicecheck.appattest-environment': 'production'
-      }
+      },
+      // iOS Universal Links: lets https://<host>/onramp-return (and other
+      // allowlisted paths) open this app directly. The host must serve the AASA
+      // file at /.well-known/apple-app-site-association (see server/api/aasa.js).
+      // No protocol prefix here — Apple expects just `applinks:<host>`.
+      associatedDomains: ['applinks:onramp-v2-mobile-demo-murex.vercel.app']
     },
 
     android: {

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -98,6 +98,7 @@ import { Linking, Pressable, StyleSheet, Text, View } from "react-native";
 import { APIGuestCheckoutWidget, OnrampForm, useApp2App, useOnramp } from "../../components";
 import { CoinbaseAlert } from "../../components/ui/CoinbaseAlerts";
 import { CoinbaseAppStatus } from "../../components/ui/CoinbaseAppStatus";
+import { AppAttestReset } from "../../components/ui/AppAttestReset";
 import { COLORS } from "../../constants/Colors";
 import { TEST_ACCOUNTS } from "../../constants/TestAccounts";
 import { clearPhoneVerifyWasCanceled, getCountry, getCurrentNetwork, getCurrentPartnerUserRef, getCurrentWalletAddress, getPendingForm, getPhoneVerifyWasCanceled, getSandboxMode, getSubdivision, getTestWalletEvm, getTestWalletSol, getVerifiedPhone, isPhoneFresh60d, isTestSessionActive, setCurrentSolanaAddress, setCurrentWalletAddress, setPendingForm } from "../../utils/sharedState";
@@ -781,6 +782,10 @@ export default function Index() {
 
       {/* Partner signal: is the Coinbase retail app installed on this device? */}
       <CoinbaseAppStatus />
+
+      {/* Clears a stale App Attest key (keychain survives reinstall) so a fresh
+          attest + registration runs on the next app2app attempt. */}
+      <AppAttestReset />
 
       {/* Error banner for failed options fetch */}
       {optionsError && !isLoadingOptions && (

--- a/components/ui/AppAttestReset.tsx
+++ b/components/ui/AppAttestReset.tsx
@@ -1,0 +1,91 @@
+/**
+ * ============================================================================
+ * AppAttestReset — CLEAR DEVICE ATTESTATION STATE (iOS)
+ * ============================================================================
+ *
+ * Small maintenance control that wipes the stored App Attest keyId + attested /
+ * registered markers (see utils/appAttest → clearAllAppAttestKeys). These live
+ * in the iOS keychain and persist across app delete/reinstall for the same
+ * bundle id, so a key provisioned during local/dev testing can be reused — and
+ * then rejected at the per-transaction assertion (signature) step — by a later
+ * TestFlight build. Tapping this forces a fresh attest + registration on the
+ * next app2app run. iOS-only; renders nothing elsewhere.
+ * ============================================================================
+ */
+
+import React, { useState } from "react";
+import { Alert, Platform, Pressable, StyleSheet, Text } from "react-native";
+import { COLORS } from "../../constants/Colors";
+import { clearAllAppAttestKeys } from "../../utils/appAttest";
+
+const { TEXT_SECONDARY, BORDER } = COLORS;
+
+export function AppAttestReset() {
+  const [busy, setBusy] = useState(false);
+
+  if (Platform.OS !== "ios") return null;
+
+  const onReset = () => {
+    Alert.alert(
+      "Reset device attestation?",
+      "Clears the stored App Attest key so the next app-to-app run provisions a fresh one. Use this if you see a signature/attestation error.",
+      [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Reset",
+          style: "destructive",
+          onPress: async () => {
+            setBusy(true);
+            try {
+              await clearAllAppAttestKeys();
+              Alert.alert(
+                "Attestation cleared",
+                "A fresh key will be created on your next app-to-app attempt.",
+              );
+            } catch {
+              Alert.alert(
+                "Reset failed",
+                "Could not clear the stored attestation key. Please try again.",
+              );
+            } finally {
+              setBusy(false);
+            }
+          },
+        },
+      ],
+    );
+  };
+
+  return (
+    <Pressable
+      onPress={onReset}
+      disabled={busy}
+      style={({ pressed }) => [styles.button, pressed && styles.pressed]}
+      accessibilityRole="button"
+    >
+      <Text style={styles.text}>
+        {busy ? "Resetting…" : "Reset device attestation"}
+      </Text>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  button: {
+    alignSelf: "center",
+    paddingVertical: 8,
+    paddingHorizontal: 14,
+    marginTop: 12,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: BORDER,
+  },
+  pressed: {
+    opacity: 0.6,
+  },
+  text: {
+    fontSize: 12,
+    color: TEXT_SECONDARY,
+    fontWeight: "600",
+  },
+});

--- a/hooks/useApp2App.ts
+++ b/hooks/useApp2App.ts
@@ -73,6 +73,18 @@ const BUNDLE_ID = APP_ATTEST_APP_ID.includes(".")
   : APP_ATTEST_APP_ID;
 
 /**
+ * Heuristic: does this error look like the server rejecting the device key /
+ * its assertion (signature)? Used to decide whether to reset the key and retry.
+ * Matches attestation/assertion/signature wording and "not registered" cases.
+ */
+function isAttestationKeyError(err: unknown): boolean {
+  const msg = (err instanceof Error ? err.message : String(err ?? "")).toLowerCase();
+  return /attest|assert|signature|invalid.*key|device.*key|not.*regist|unregist|public key/.test(
+    msg,
+  );
+}
+
+/**
  * One-time, per-install iOS App Attest device-key registration (cdp-api
  * PR #1347). No-op on Android (Play Integrity is validated inline per request)
  * and when the device key is already registered. On the simulator / Expo Go the
@@ -146,12 +158,6 @@ export function useApp2App() {
           a2aWarn('⚠️ [APP2APP] Hardware attestation unavailable — using stub attestation');
         }
 
-        // 0. One-time per-install device-key registration (iOS App Attest).
-        //    Must precede the session so the device's public key is on file for
-        //    the per-transaction assertion check.
-        await ensureDeviceRegistered();
-
-        // 1. Create the challenge + bind the transaction params server-side.
         const order: App2AppOrderParams = {
           projectId: ONRAMP_PROJECT_ID,
           appId: APP_ATTEST_APP_ID,
@@ -163,24 +169,48 @@ export function useApp2App() {
           partnerUserRef,
           redirectUrl: REDIRECT_URL,
         };
-        const { challenge } = await createOnrampMobileChallenge(order);
 
-        // 2. Per-transaction assertion bound to SHA-256(base64url_decode(challenge))
-        //    (signed with the now-registered key).
-        const attestation = await getAppAttestation(challenge);
+        // Steps 1–4: challenge → per-transaction assertion → session → hand-off.
+        const runHandoff = async (): Promise<boolean> => {
+          // 1. Create the challenge + bind the transaction params server-side.
+          const { challenge } = await createOnrampMobileChallenge(order);
+          // 2. Per-transaction assertion bound to
+          //    SHA-256(base64url_decode(challenge)), signed with the registered key.
+          const attestation = await getAppAttestation(challenge);
+          // 3. Verify the attestation → onramp session (the id for the deep link).
+          const session = await createOnrampMobileSession({ challenge, attestation });
+          // 4. Hand off to the Coinbase retail app via the onramp universal link.
+          return await openCoinbaseApp2App(session, {
+            address: params.destinationAddress,
+            asset: params.purchaseCurrency,
+            presetFiatAmount: params.paymentAmount,
+            defaultNetwork: params.destinationNetwork,
+            redirectUrl: REDIRECT_URL,
+          });
+        };
 
-        // 3. Verify the attestation → onramp session (the id for the deep link).
-        const session = await createOnrampMobileSession({ challenge, attestation });
+        // 0. One-time per-install device-key registration (iOS App Attest).
+        //    Must precede the session so the device's public key is on file for
+        //    the per-transaction assertion check.
+        await ensureDeviceRegistered();
 
-        // 4. Hand off to the Coinbase retail app via the onramp universal link,
-        //    carrying the verified session token + the order details.
-        return await openCoinbaseApp2App(session, {
-          address: params.destinationAddress,
-          asset: params.purchaseCurrency,
-          presetFiatAmount: params.paymentAmount,
-          defaultNetwork: params.destinationNetwork,
-          redirectUrl: REDIRECT_URL,
-        });
+        try {
+          return await runHandoff();
+        } catch (err) {
+          // Self-heal: a key left over from earlier (e.g. dev/local) testing can
+          // be reused but rejected at the assertion step (signature/attestation
+          // error). Drop it, re-register a fresh key, and retry the hand-off once.
+          if (Platform.OS === "ios" && isAttestationKeyError(err)) {
+            a2aWarn(
+              "🔁 [APP2APP] Assertion rejected — resetting App Attest key and retrying once",
+            );
+            await resetAppAttestKey();
+            await clearLegacyAppAttestKeys();
+            await ensureDeviceRegistered();
+            return await runHandoff();
+          }
+          throw err;
+        }
       } catch (e: any) {
         console.error('❌ [APP2APP] Flow failed:', e);
         setError(e?.message || 'App-to-app onramp failed');

--- a/hooks/useApp2App.ts
+++ b/hooks/useApp2App.ts
@@ -55,7 +55,24 @@ export interface StartApp2AppParams {
   paymentCurrency: string;      // e.g. "USD"
 }
 
-const REDIRECT_URL = "onrampdemo://onramp-return";
+// Return target the Coinbase app redirects to when the onramp completes.
+// Prefer an https Universal Link on the same origin as the API (strip the /api
+// suffix) so iOS opens this app via the AASA association
+// (server/api/aasa.js + ios.associatedDomains). Falls back to the custom scheme
+// for local/non-https backends, where Universal Links don't apply.
+function computeRedirectUrl(): string {
+  const base = process.env.EXPO_PUBLIC_BASE_URL || "";
+  try {
+    const u = new URL(base);
+    if (u.protocol === "https:") {
+      return `${u.protocol}//${u.host}/onramp-return`;
+    }
+  } catch {
+    // fall through to the custom scheme
+  }
+  return "onrampdemo://onramp-return";
+}
+const REDIRECT_URL = computeRedirectUrl();
 // App Attest App ID in `teamID.bundleID` form. Configure via env — never hardcode
 // a real team/bundle id in source (see .env.example: EXPO_PUBLIC_APP_ATTEST_APP_ID).
 const APP_ATTEST_APP_ID = process.env.EXPO_PUBLIC_APP_ATTEST_APP_ID || "";

--- a/server/api/aasa.js
+++ b/server/api/aasa.js
@@ -1,0 +1,29 @@
+/**
+ * Apple App Site Association (AASA) for iOS Universal Links.
+ *
+ * Served at https://<domain>/.well-known/apple-app-site-association via the
+ * vercel.json rewrite (Apple fetches that well-known path; it must return 200
+ * JSON over HTTPS with no redirect). Declares which paths on this domain open
+ * the native app instead of the website — used for the app2app onramp return
+ * (`/onramp-return`) and the offramp send hand-off (`/offramp-send`).
+ *
+ * appID is `teamID.bundleID` (public, also embedded in the app binary). Keep it
+ * in sync with EXPO_PUBLIC_APP_ATTEST_APP_ID / the build's signing.
+ */
+const AASA = {
+  applinks: {
+    apps: [],
+    details: [
+      {
+        appID: '3W8D3S7TCY.com.coinbase.cdp-onramp',
+        paths: ['/onramp-return', '/onramp-return/*', '/offramp-send', '/offramp-send/*'],
+      },
+    ],
+  },
+};
+
+export default function handler(req, res) {
+  res.setHeader('Content-Type', 'application/json');
+  res.setHeader('Cache-Control', 'public, max-age=3600');
+  res.status(200).json(AASA);
+}

--- a/server/vercel.json
+++ b/server/vercel.json
@@ -1,5 +1,6 @@
 {
   "rewrites": [
-    { "source": "/api/app2app/(.*)", "destination": "/api/app2app" }
+    { "source": "/api/app2app/(.*)", "destination": "/api/app2app" },
+    { "source": "/.well-known/apple-app-site-association", "destination": "/api/aasa" }
   ]
 }

--- a/utils/appAttest.ts
+++ b/utils/appAttest.ts
@@ -479,3 +479,16 @@ export async function clearLegacyAppAttestKeys(): Promise<void> {
     LEGACY_STORE_KEYS.map((k) => SecureStore.deleteItemAsync(k).catch(() => {})),
   );
 }
+
+/**
+ * Full reset of all App Attest state on this device: the current project-scoped
+ * keyId/attested/registered markers AND the pre-scoping legacy entries. The
+ * stored keyId lives in the iOS keychain, which survives an app delete/reinstall
+ * for the same bundle id — so a key created during local/dev testing can be
+ * reused (and rejected at the assertion step) by a later TestFlight build. Use
+ * this to force a clean attest + registration on the next app2app run.
+ */
+export async function clearAllAppAttestKeys(): Promise<void> {
+  await resetAppAttestKey();
+  await clearLegacyAppAttestKeys();
+}


### PR DESCRIPTION
## Summary

Follow-up to #42. Two changes:

### 1. Recover from stale App Attest keys (the "signature error" on TestFlight)
The App Attest `keyId` is stored in the iOS **keychain**, which survives app
delete/reinstall for the same bundle id, and a key is bound to its App Attest
**environment** (dev sandbox vs production). A key created by a local/dev build
can therefore be reused — and then rejected at the per-transaction assertion
(signature) step — by a later TestFlight build on the same device. (Scoping the
stored keys by project id in #42 didn't catch this because the project id is the
same across dev and prod; the real discriminator is the App Attest environment.)

- Add `clearAllAppAttestKeys()` (clears the project-scoped + legacy entries).
- Add a **"Reset device attestation"** button on the Home screen to force a fresh
  key manually.
- **Self-heal** in the app2app flow: on a signature/attestation error, reset the
  key, re-register, and retry the hand-off once — so a stale key recovers
  automatically instead of failing permanently.

### 2. Document TestFlight / App Store builds
`/ios` and `.env` are git-ignored, so a fresh clone needs a real `.env` and an
`expo prebuild` — the most common reason a teammate's build installs but fails
sign-in / app2app.

- New README section **"Building for TestFlight / App Store (App2App + App
  Attest)"** with the required `.env`, prebuild + pod install, signing, and
  archive/upload steps.
- Clarify env vars in `.env.example` + README: `EXPO_PUBLIC_USE_EXPO_CRYPTO` must
  be `false` for native/TestFlight builds, `EXPO_PUBLIC_BASE_URL` needs the `/api`
  suffix on Vercel, and the `ONRAMP_PROJECT_ID` / `APP_ATTEST_APP_ID` requirements.

## Commits
- `feat: self-heal stale App Attest key + manual reset control`
- `docs: document TestFlight build + app2app env vars`

## Test plan
- [x] On a device with a stale dev key, the TestFlight/Release build recovers
      (self-heal) and completes the app2app hand-off
- [x] "Reset device attestation" clears the key; next app2app run re-attests +
      re-registers cleanly
- [ ] Clean-device app2app flow still works end-to-end (no regression)
- [ ] Teammate can build for TestFlight following the new README section