### PR TITLE
fix(onramp): use the Solana address for Solana networks

### DIFF
--- a/components/onramp/OnrampForm.tsx
+++ b/components/onramp/OnrampForm.tsx
@@ -226,9 +226,12 @@ const usSubs = useMemo(() => {
     if (prevNetworkRef.current === network) return;
     prevNetworkRef.current = network;
 
-    if (!localSandboxEnabled && (isEvmNetwork || isSolanaNetwork)) {
-      // Only update address for supported networks (EVM/Solana) in production mode
-      // For unsupported networks (Noble, etc.), don't auto-update
+    if (isEvmNetwork || isSolanaNetwork) {
+      // Refresh the address for supported networks (EVM/Solana) in BOTH sandbox and
+      // production. getCurrentWalletAddress() is network-aware (and shape-checks any
+      // manual address), so switching to Solana swaps in the Solana address instead
+      // of keeping the previous EVM address. Unsupported networks (Noble, etc.) are
+      // intentionally left alone. The null guard avoids clobbering a valid address.
       const { getCurrentWalletAddress } = require('../../utils/sharedState');
       const newAddress = getCurrentWalletAddress();
       if (newAddress && newAddress !== address) {

--- a/utils/sharedState.ts
+++ b/utils/sharedState.ts
@@ -285,19 +285,27 @@ export const getCurrentNetwork = () => currentNetwork;
  * - EVM networks: EVM wallet only
  * - Unsupported networks: null (no address)
  */
+// Address-shape guards so a manual address typed for one chain isn't reused on
+// another (e.g. a 0x… EVM address must never be sent for a Solana onramp).
+const isEvmAddress = (addr: string | null): boolean => !!addr && /^0x[0-9a-fA-F]{40}$/.test(addr);
+const isSolanaAddress = (addr: string | null): boolean =>
+  !!addr && addr.length >= 32 && addr.length <= 44 && /^[1-9A-HJ-NP-Za-km-z]+$/.test(addr);
+
 export const getCurrentWalletAddress = () => {
   const networkLower = (currentNetwork || '').toLowerCase();
   const isSolanaNetwork = ['solana', 'sol'].some(k => networkLower.includes(k));
   const isEvmNetwork = ['ethereum', 'base', 'unichain', 'polygon', 'arbitrum', 'optimism', 'avalanche', 'avax', 'bsc', 'fantom', 'linea', 'zksync', 'scroll'].some(k => networkLower.includes(k));
 
   if (sandboxMode) {
-    // Sandbox mode: allow testing with any address
+    // Sandbox mode: allow testing with a manual address, but only when its shape
+    // matches the selected network — otherwise fall back to the network wallet so
+    // we never send an EVM address to Solana (or vice versa).
     if (isSolanaNetwork) {
-      // SOL network: prefer manual, fallback to SOL wallet
-      return manualWalletAddress || currentSolanaAddress || null;
+      // SOL network: manual (only if it's a valid Solana address) > SOL wallet
+      return (isSolanaAddress(manualWalletAddress) ? manualWalletAddress : null) || currentSolanaAddress || null;
     } else {
-      // EVM and ANY other network (including unsupported): prefer manual, fallback to EVM wallet
-      return manualWalletAddress || currentWalletAddress || null;
+      // EVM and ANY other network: manual (only if it's a valid EVM address) > EVM wallet
+      return (isEvmAddress(manualWalletAddress) ? manualWalletAddress : null) || currentWalletAddress || null;
     }
   } else {
     // Production mode: strict network-wallet matching


### PR DESCRIPTION
Selecting a Solana network (e.g. USDC on Solana) could submit the EVM 0x… address as the destination, which the onramp API rejects as an invalid address. Two causes:

- OnrampForm only refreshed the network-aware address in production, so in sandbox (the default) the address kept its previous EVM value when switching to Solana.
- In sandbox, a manual address was reused for every network, so a 0x… manual address was sent for Solana.

Refresh the address on every network change (sandbox + production) and shape-check the manual address against the selected network, falling back to the matching network wallet when it doesn't match.