### PR TITLE
feat(app2app): adopt cdp-api v1.41.0 path-param mobile attestation endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,14 @@ EXPO_PUBLIC_ONRAMP_PROJECT_ID=YOUR_ONRAMP_PROJECT_ID
 # use http://BACKEND_SERVER:3000 (no /api suffix).
 EXPO_PUBLIC_BASE_URL=http://BACKEND_SERVER:3000
 
+# Optional: explicit app2app return (redirect) URL. Must be a host in the CDP
+# project's redirect allowlist AND carry the AASA for this app's Universal Link
+# (ios.associatedDomains) so the Coinbase app can reopen us. Only needed when the
+# API base above is NOT the public app domain — e.g. when proxying API traffic
+# through a tunnel for debugging. When unset, the redirect is derived from the
+# https origin of EXPO_PUBLIC_BASE_URL (falling back to the onrampdemo:// scheme).
+# EXPO_PUBLIC_APP2APP_REDIRECT_URL=https://<project>.vercel.app/onramp-return
+
 # Crypto implementation selector. THIS MATTERS FOR APP2APP / APP ATTEST:
 # - true  -> Expo Go (npx expo start): uses expo-crypto. App Attest returns a
 #            MOCK attestation that the server rejects — app2app will NOT work.

--- a/hooks/useApp2App.ts
+++ b/hooks/useApp2App.ts
@@ -56,11 +56,20 @@ export interface StartApp2AppParams {
 }
 
 // Return target the Coinbase app redirects to when the onramp completes.
-// Prefer an https Universal Link on the same origin as the API (strip the /api
-// suffix) so iOS opens this app via the AASA association
-// (server/api/aasa.js + ios.associatedDomains). Falls back to the custom scheme
-// for local/non-https backends, where Universal Links don't apply.
+//
+// This must be (a) a host in the CDP project's redirect domain allowlist and
+// (b) a domain whose AASA points back at this app (ios.associatedDomains) so the
+// Universal Link reopens us. That is the stable public app domain, which is NOT
+// necessarily the API base: when API traffic is proxied elsewhere for debugging
+// (e.g. a Cloudflare tunnel to the local server), the redirect must still use the
+// allowlisted app domain. Resolution order:
+//   1. EXPO_PUBLIC_APP2APP_REDIRECT_URL — explicit override (use when the API base
+//      is a tunnel/non-allowlisted host).
+//   2. https origin of EXPO_PUBLIC_BASE_URL — when the API base IS the app domain.
+//   3. custom scheme — local/non-https backends where Universal Links don't apply.
 function computeRedirectUrl(): string {
+  const override = process.env.EXPO_PUBLIC_APP2APP_REDIRECT_URL;
+  if (override) return override;
   const base = process.env.EXPO_PUBLIC_BASE_URL || "";
   try {
     const u = new URL(base);

--- a/server/api/app2app.js
+++ b/server/api/app2app.js
@@ -5,8 +5,8 @@ import app from '../src/app.js';
  *
  * The app2app onramp routes are defined on the shared Express app
  * (see server/src/app.ts): /app2app/mobile/challenges, /sessions, and the
- * /app2app/mobile/attestation/{challenges,registrations} device-attestation
- * endpoints.
+ * /app2app/mobile/projects/{projectId}/attestation/{challenges,registrations/{keyId}}
+ * device-attestation endpoints.
  *
  * Vercel's zero-config builder does not reliably expose a `[...slug]` catch-all
  * for plain Node functions (it only matched a single path segment), so instead

--- a/server/api/app2app/[...slug].js
+++ b/server/api/app2app/[...slug].js
@@ -5,8 +5,8 @@ import app from '../../src/app.js';
  *
  * The app2app onramp routes are defined on the shared Express app
  * (see server/src/app.ts): /app2app/mobile/challenges, /sessions, and the
- * /app2app/mobile/attestation/{challenges,registrations} device-attestation
- * endpoints. Vercel's file-based routing only exposes files under api/, so this
+ * /app2app/mobile/projects/{projectId}/attestation/{challenges,registrations/{keyId}}
+ * device-attestation endpoints. Vercel's file-based routing only exposes files under api/, so this
  * single catch-all forwards all of them to the Express app rather than adding a
  * separate function file per route.
  *

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -378,6 +378,7 @@ async function proxyOnrampMobile(
   body: unknown,
   extraHeaders: Record<string, string>,
   res: import('express').Response,
+  method: 'POST' | 'PUT' = 'POST',
 ): Promise<void> {
   const startedAt = Date.now();
 
@@ -396,7 +397,7 @@ async function proxyOnrampMobile(
       const token = await generateJwt({
         apiKeyId: process.env.CDP_API_KEY_ID,
         apiKeySecret: process.env.CDP_API_KEY_SECRET,
-        requestMethod: 'POST',
+        requestMethod: method,
         requestHost: u.hostname,
         requestPath: u.pathname, // no query string — CDP signs pathname only
         expiresIn: 120,
@@ -408,18 +409,28 @@ async function proxyOnrampMobile(
     }
   }
 
+  // Some endpoints (e.g. the attestation challenge, whose params are all in the
+  // path) take no request body; skip serializing one so we don't send `{}`.
+  const hasBody = body !== undefined && body !== null;
+
   if (APP2APP_VERBOSE) {
     console.log(`\n┌─ [APP2APP] ${label} ▶ REQUEST ────────────────────────────────`);
-    console.log(`│ POST ${upstreamUrl}  (jwt=${jwtAttached})`);
-    console.log(`│ body: ${JSON.stringify(body ?? {}, null, 2).replace(/\n/g, '\n│ ')}`);
+    console.log(`│ ${method} ${upstreamUrl}  (jwt=${jwtAttached})`);
+    if (hasBody) {
+      console.log(`│ body: ${JSON.stringify(body, null, 2).replace(/\n/g, '\n│ ')}`);
+    }
     console.log(`└──────────────────────────────────────────────────────────────`);
   }
 
-  const upstream = await fetch(upstreamUrl, {
-    method: 'POST',
+  const requestInit: RequestInit = {
+    method,
     headers: { 'Content-Type': 'application/json', ...authHeaders, ...extraHeaders },
-    body: JSON.stringify(body ?? {}),
-  });
+  };
+  if (hasBody) {
+    requestInit.body = JSON.stringify(body);
+  }
+
+  const upstream = await fetch(upstreamUrl, requestInit);
 
   const text = await upstream.text();
   let data: unknown;
@@ -483,29 +494,32 @@ app.post('/app2app/mobile/sessions', async (req, res) => {
 });
 
 /**
- * One-time iOS App Attest device-key REGISTRATION (cdp-api PR #1347,
- * c3/cdp-api → /v2/onramp/mobile/attestation/*). iOS-only; Android validates
+ * One-time iOS App Attest device-key REGISTRATION (c3/cdp-api → /v2/onramp/
+ * mobile/projects/{projectId}/attestation/*). iOS-only; Android validates
  * Play Integrity inline per request and has no registration step.
  *
- *   A. POST /app2app/mobile/attestation/challenges    → { challenge, expiresAt }
- *        Issues a one-time registration challenge for this project.
- *   B. POST /app2app/mobile/attestation/registrations → { identifier, keyId, … }
- *        Verifies the Apple attestation object signed over SHA-256(challenge)
- *        and stores the device public key for later assertion checks.
+ *   A. POST /app2app/mobile/projects/:projectId/attestation/challenges
+ *        → { challenge, expiresAt }  — one-time registration challenge.
+ *   B. PUT  /app2app/mobile/projects/:projectId/attestation/registrations/:keyId
+ *        → { appId, keyId, … }  — verifies the Apple attestation object signed
+ *        over SHA-256(challenge) and stores the device public key.
  *
- * Both are public/unauthenticated (trust comes from the attestation itself), so
- * we forward without a CDP JWT, mirroring the challenge/session proxies above.
+ * Per onramp-service PR #1840 (cdp-api v1.41.0 strict handlers), projectId and
+ * keyId are path parameters (projectId uuid-validated upstream) and registration
+ * is a PUT keyed on keyId. Both are public/unauthenticated (trust comes from the
+ * attestation itself), so we forward without a CDP JWT.
  */
 
-// Step A — issue a one-time iOS App Attest registration challenge.
-app.post('/app2app/mobile/attestation/challenges', async (req, res) => {
+// Step A — issue a one-time iOS App Attest registration challenge. projectId is
+// a path param; the upstream endpoint takes no request body.
+app.post('/app2app/mobile/projects/:projectId/attestation/challenges', async (req, res) => {
   try {
-    const body = req.body ?? {};
+    const { projectId } = req.params;
 
     await proxyOnrampMobile(
       'createOnrampAttestationChallenge',
-      `${onrampMobileBase()}/attestation/challenges`,
-      body,
+      `${onrampMobileBase()}/projects/${encodeURIComponent(projectId)}/attestation/challenges`,
+      undefined,
       {},
       res,
     );
@@ -516,22 +530,28 @@ app.post('/app2app/mobile/attestation/challenges', async (req, res) => {
 });
 
 // Step B — verify the attestation object & register the device public key.
-app.post('/app2app/mobile/attestation/registrations', async (req, res) => {
-  try {
-    const body = req.body ?? {};
+// projectId and keyId are path params; the body carries { challenge, ios }.
+app.put(
+  '/app2app/mobile/projects/:projectId/attestation/registrations/:keyId',
+  async (req, res) => {
+    try {
+      const { projectId, keyId } = req.params;
+      const body = req.body ?? {};
 
-    await proxyOnrampMobile(
-      'registerOnrampAttestation',
-      `${onrampMobileBase()}/attestation/registrations`,
-      body,
-      {},
-      res,
-    );
-  } catch (error) {
-    console.error('❌ [APP2APP] attestation registration proxy error:', error);
-    res.status(502).json({ errorMessage: 'Failed to reach onramp attestation registration API' });
-  }
-});
+      await proxyOnrampMobile(
+        'registerOnrampAttestation',
+        `${onrampMobileBase()}/projects/${encodeURIComponent(projectId)}/attestation/registrations/${encodeURIComponent(keyId)}`,
+        body,
+        {},
+        res,
+        'PUT',
+      );
+    } catch (error) {
+      console.error('❌ [APP2APP] attestation registration proxy error:', error);
+      res.status(502).json({ errorMessage: 'Failed to reach onramp attestation registration API' });
+    }
+  },
+);
 
 // Zod schema for EVM balance query validation (SSRF protection)
 const evmBalanceQuerySchema = z.object({

--- a/utils/createApp2AppSession.ts
+++ b/utils/createApp2AppSession.ts
@@ -106,7 +106,7 @@ export interface IosAttestationPayload {
  */
 export interface OnrampAttestationRegistration {
   /** The matched `teamID.bundleID` allowlist entry the device registered under. */
-  identifier: string;
+  appId: string;
   /** The registered App Attest key id — reused for subsequent assertions. */
   keyId: string;
   /** Always "ios" — registration is iOS-only. */
@@ -175,11 +175,15 @@ export async function createOnrampMobileChallenge(
  *   2. attestDeviceKey(challenge)         (see utils/appAttest.ts)
  *        → CBOR attestation object over SHA-256(challenge)
  *   3. registerOnrampAttestation({ projectId, challenge, ios })
- *        → { identifier, keyId, … } — device public key now stored upstream
+ *        → { appId, keyId, … } — device public key now stored upstream
  *
- * Both endpoints are public/unauthenticated and reached via the server proxy:
- *   POST /app2app/mobile/attestation/challenges    → …/v2/onramp/mobile/attestation/challenges
- *   POST /app2app/mobile/attestation/registrations → …/v2/onramp/mobile/attestation/registrations
+ * Both endpoints are public/unauthenticated and reached via the server proxy.
+ * Per onramp-service PR #1840 (cdp-api v1.41.0 strict handlers), projectId and
+ * keyId are PATH parameters, and registration is a PUT keyed on keyId:
+ *   POST /app2app/mobile/projects/{projectId}/attestation/challenges
+ *        → …/v2/onramp/mobile/projects/{projectId}/attestation/challenges
+ *   PUT  /app2app/mobile/projects/{projectId}/attestation/registrations/{keyId}
+ *        → …/v2/onramp/mobile/projects/{projectId}/attestation/registrations/{keyId}
  * ============================================================================
  */
 
@@ -193,11 +197,14 @@ export async function createOnrampAttestationChallenge(
 ): Promise<App2AppChallenge> {
   a2aLog('📤 [APP2APP] createOnrampAttestationChallenge', { projectId });
 
-  const res = await fetch(`${BASE_URL}/app2app/mobile/attestation/challenges`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ projectId }),
-  });
+  // projectId is a path parameter (uuid-validated upstream); no request body.
+  const res = await fetch(
+    `${BASE_URL}/app2app/mobile/projects/${encodeURIComponent(projectId)}/attestation/challenges`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    },
+  );
 
   a2aLog('📥 [APP2APP] attestation challenge status:', res.status, res.statusText);
 
@@ -214,8 +221,12 @@ export async function createOnrampAttestationChallenge(
 
 /**
  * Registration step 2 — verify the Apple attestation and register the device's
- * public key. iOS-only. Returns the matched allowlist `identifier` and the
+ * public key. iOS-only. Returns the matched allowlist `appId` and the
  * registered `keyId` to reuse for subsequent assertions.
+ *
+ * Per onramp-service PR #1840, this is a PUT with `projectId` and `keyId` as
+ * path parameters; the body carries only the challenge and the attestation
+ * material (`attestation`, `bundleId`).
  */
 export async function registerOnrampAttestation(args: {
   projectId: string;
@@ -223,18 +234,25 @@ export async function registerOnrampAttestation(args: {
   ios: IosAttestationPayload;
 }): Promise<OnrampAttestationRegistration> {
   const { projectId, challenge, ios } = args;
+  const { keyId, attestation, bundleId } = ios;
 
   a2aLog('📤 [APP2APP] registerOnrampAttestation', {
     projectId,
-    keyId: ios.keyId?.slice(0, 8),
-    bundleId: ios.bundleId,
+    keyId: keyId?.slice(0, 8),
+    bundleId,
   });
 
-  const res = await fetch(`${BASE_URL}/app2app/mobile/attestation/registrations`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ projectId, challenge, ios }),
-  });
+  // keyId is the authoritative device-key id in the path; it is also included in
+  // the body's `ios` payload to match the cdp-api IosAttestationPayload schema
+  // (attestation, bundleId, keyId) that the generated SDK sends.
+  const res = await fetch(
+    `${BASE_URL}/app2app/mobile/projects/${encodeURIComponent(projectId)}/attestation/registrations/${encodeURIComponent(keyId)}`,
+    {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ challenge, ios: { keyId, attestation, bundleId } }),
+    },
+  );
 
   a2aLog('📥 [APP2APP] attestation registration status:', res.status, res.statusText);
 
@@ -243,10 +261,10 @@ export async function registerOnrampAttestation(args: {
   }
 
   const data = await res.json();
-  if (!data?.identifier || !data?.keyId) {
+  if (!data?.appId || !data?.keyId) {
     throw new Error(`Unexpected registration response: ${JSON.stringify(data)}`);
   }
-  a2aLog('✅ [APP2APP] device registered:', data.identifier);
+  a2aLog('✅ [APP2APP] device registered:', data.appId);
   return data as OnrampAttestationRegistration;
 }
 


### PR DESCRIPTION
## Summary
- Aligns the demo client (`utils/createApp2AppSession.ts`) and server proxy (`server/src/app.ts`) with onramp-service PR #1840, which moved the iOS device-attestation endpoints to path-param strict-handler routes.
- Attestation challenge: `POST .../projects/{projectId}/attestation/challenges` (projectId in path, no body).
- Attestation registration: `PUT .../projects/{projectId}/attestation/registrations/{keyId}` (projectId + keyId in path; body = challenge + ios payload); response field `identifier` -> `appId`.
- Decouples the app2app redirect from the API base via a new `EXPO_PUBLIC_APP2APP_REDIRECT_URL` override so API traffic can be tunneled for debugging while the redirect stays on the allowlisted, AASA-backed app domain.
- Session challenge/session endpoints unchanged.

## Test plan
- [x] `tsc` clean (app + server)
- [x] Verified path/method/body/response against merged onramp-service master + generated cdp-api v1.41.0 types
- [ ] On-device: reset attestation -> run app2app -> confirm new challenge (201) + registration (200 w/ appId)
